### PR TITLE
Fix typo: declarative -> imperative

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Comments welcome.  I'm new to typescript.
 
 ## Purpose
 
-Useful on the boundary between a declarative (get, set) code base and a reactive (streaming) code base.  Uses Most.js for streams. 
+Useful on the boundary between a imperative (get, set) code base and a reactive (streaming) code base.  Uses Most.js for streams. 
 
 ## Use
 


### PR DESCRIPTION
Based on the description & the rest of the README, I think this was a typo.